### PR TITLE
Parse boolean using string comparison instead of Boolean()

### DIFF
--- a/src/odata-grammar-filter.ts
+++ b/src/odata-grammar-filter.ts
@@ -361,7 +361,7 @@ function peg$parse(input: string, options?: IParseOptions) {
   const peg$c58 = function(value: any): any {
         return {
           type: 'primitive',
-          value: Boolean(value),
+          value: value === "true" ? true : false,
         };
       };
   const peg$c59 = "null";

--- a/src/odata-grammar-order-by.ts
+++ b/src/odata-grammar-order-by.ts
@@ -361,7 +361,7 @@ function peg$parse(input: string, options?: IParseOptions) {
   const peg$c58 = function(value: any): any {
         return {
           type: 'primitive',
-          value: Boolean(value),
+          value: value === "true" ? true : false,
         };
       };
   const peg$c59 = "null";

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -192,7 +192,7 @@ boolean
   = value:("true"i / "false"i) {
       return {
         type: 'primitive',
-        value: Boolean(value),
+        value: value === "true" ? true : false,
       };
     }
 


### PR DESCRIPTION
Thank you for the great script!

I'd like to suggest changing the method of parsing a boolean value. Currently, the code is using Boolean(), which [will return true for any object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean), including the string "false", leading to unexpected results, like in this example.


**_Input:_** 
```
'property eq false'
```

**_Previous Output:_** 
```
{
     type: 'eqExpr', 
     left: {
          type: 'memberExpr', value: 'property'
     }, 
     right: {
          type: 'primitive', value: true
     }
}
```


For that same input, here is the output upon basing the boolean value on a string comparison with "true" or "false" instead, which is the code change I have made in this PR.

**_New Output:_** 

```
{
     type: 'eqExpr', 
     left: {
          type: 'memberExpr', value: 'property'
     }, 
     right: {
          type: 'primitive', value: false
     }
}
``````