### PR TITLE
Required changes to support nodenext

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "require": "./dist/odata-filter-to-ast.cjs",
-      "import": "./dist/odata-filter-to-ast.es.js"
+      "import": "./dist/odata-filter-to-ast.es.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "main": "dist/odata-filter-to-ast.cjs",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "license": "MIT",
   "author": "Petr Zahradník",
-  "type": "module",
   "exports": {
     ".": {
       "require": "./dist/odata-filter-to-ast.cjs",


### PR DESCRIPTION
`nodenext` style resolution ignores the top-level `types` reference when there's an `exports`. A `types` in the various exports is required.

Also, in a multi-type module like this, where you offer both import and require, don't set the `type` field. The `type` field forces TypeScript module resolution to see the whole package as a `module` before it even evaluates the `nodenext`. This isn't either module or commonjs; its both, depending on the consumer. Even without `nodenext`, setting `main` and `module` properties handles this correctly without the `type`.